### PR TITLE
Add the ARM platform support

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,34 +2,38 @@ name: Massa
 
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    tags:
+      - TEST.*
 
 jobs:
 
   build:
     runs-on: ubuntu-latest
 
+    env:
+      VERSION: ${{ github.ref_name }}
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Massa image
-      run: docker build . --file Dockerfile --tag rykcod/massa:latest
+      - name: Checkout the source code
+        uses: actions/checkout@v2
 
-    - name: Login to DockerHub
-      uses: docker/login-action@v1 
-      with:
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
-    - name: Get smart tag
-      id: prepare
-      uses: Surgo/docker-smart-tag-action@v1
-      with:
-        docker_image: rykcod/massa
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-    - name: Build and push
-      uses: docker/build-push-action@v2
-      with:
-        push: true
-        tags: rykcod/massa:episode13.0.3,rykcod/massa:latest
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: VERSION=${{ env.VERSION }}
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ${{ github.repository }}:${{ env.VERSION }}, ${{ github.repository }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,36 @@
 # Download custom base
 FROM ubuntu:20.04
- 
+
+# Build Arguments
+ARG VERSION
+
+ARG MASSA_PACKAGE="massa_${VERSION}_release_linux.tar.gz"
+ARG MASSA_PACKAGE_ARM64="massa_${VERSION}_release_linux_arm64.tar.gz"
+ARG MASSA_PACKAGE_LOCATION="https://github.com/massalabs/massa/releases/download/$VERSION/"
+
 # LABEL about the custom image
 LABEL maintainer="benoit@alphatux.fr"
-LABEL version="0.13.0.2"
-LABEL description="Node Massa"
- 
+LABEL version=$VERSION
+LABEL description="Massa node"
+
 # Set timezone and default cli
 SHELL ["/bin/bash", "-c"]
 ENV DEBIAN_FRONTEND="noninteractive" TZ="Europe/Paris"
 
-# Update and install packages
+# Update and install packages dependencies
 RUN apt-get update \
 && apt-get upgrade -y \
 && apt install -y curl wget screen procps python3-pip netcat \
 && apt autoclean -y \
 && python3 -m pip install -U discord.py
 
-# Download Testnet 13.0 Massa binaries
-RUN wget https://github.com/massalabs/massa/releases/download/TEST.13.0/massa_TEST.13.0_release_linux.tar.gz \
-&& tar -zxpf massa_TEST.13.0_release_linux.tar.gz \
-&& rm -f massa_TEST.13.0_release_linux.tar.gz
+# Update the package name if building for arm64 platform
+RUN if [[ $TARGETPLATFORM =~ linux/arm* ]]; then MASSA_PACKAGE=MASSA_PACKAGE_ARM64; fi
+
+# Download testnet Massa binaries
+RUN wget "$MASSA_PACKAGE_LOCATION/$MASSA_PACKAGE" \
+&& tar -zxpf $MASSA_PACKAGE \
+&& rm -f $MASSA_PACKAGE
 
 # Create massa-guard tree
 RUN mkdir /massa-guard \


### PR DESCRIPTION
Add some changes :
- Building of the Docker image for linux arm64 platforms.
- Use of  variables to not have the version hard-coded in the `Dockerfile` and the `docker-image.yml`.
- Github Action now triggerred by a push of a tag that starts with "TEST." : this is the massa way.